### PR TITLE
Fix: ci-vagrant

### DIFF
--- a/ci-vagrant/Vagrantfile
+++ b/ci-vagrant/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "ubuntu/xenial64"
-  config.vm.box_url = "https://atlas.hashicorp.com/ubuntu/boxes/xenial64/versions/20161104.0.0"
+  config.vm.box_version = "20161104.0.0"
 
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.provider "virtualbox" do |v|

--- a/ci-vagrant/Vagrantfile
+++ b/ci-vagrant/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
     apt-get install -y docker-engine
 
     # Install Jenkins
-    wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
+    wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | sudo apt-key add -
     echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list
     apt-get update
     apt-get install -y jenkins


### PR DESCRIPTION
1.  Fix: Vagrant box was failing to install. Set the version differently.
2. Fix: Jenkins apt-key was failing. Updated this. 